### PR TITLE
fix(main): f-string unmatched '(' error

### DIFF
--- a/maestro/main.py
+++ b/maestro/main.py
@@ -2293,7 +2293,7 @@ def clips_(songs: tuple[helpers.Song]):
 
         if "default" in song.clips:
             click.echo(
-                f"\t{style_clip_name("default", song)}: {song.clips['default'][0]}, {song.clips['default'][1]}"
+                f"\t{style_clip_name('default', song)}: {song.clips['default'][0]}, {song.clips['default'][1]}"
             )
         for clip_name, (start, end) in song.clips.items():
             if clip_name == "default":


### PR DESCRIPTION
I get this error:
```python
Traceback (most recent call last):
  File "C:\Users\ghoul\AppData\Local\Programs\Python\Python310\lib\runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "C:\Users\ghoul\AppData\Local\Programs\Python\Python310\lib\runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "C:\Users\ghoul\AppData\Local\Programs\Python\Python310\Scripts\maestro.exe\__main__.py", line 4, in <module>
  File "C:\Users\ghoul\AppData\Local\Programs\Python\Python310\lib\site-packages\maestro\main.py", line 2296
    f"\t{style_clip_name("default", song)}: {song.clips['default'][0]}, {song.clips['default'][1]}"
                          ^^^^^^^
SyntaxError: f-string: unmatched '('
```

Fixed it by changing double quotes to single quotes